### PR TITLE
internal/database: simplify database implementation and API. WARNING: not backwards compatible

### DIFF
--- a/internal/database/badgerdb/badgerdb.go
+++ b/internal/database/badgerdb/badgerdb.go
@@ -153,7 +153,7 @@ func (db *Database) get(ctx context.Context, key []byte, buf *bytes.Buffer) erro
 		return err
 	}
 	err := db.bdb.View(func(tx *badger.Txn) error {
-		item, err := tx.Get([]byte(key))
+		item, err := tx.Get(key)
 		if err != nil {
 			if err == badger.ErrKeyNotFound {
 				return nil

--- a/internal/database/badgerdb/badgerdb_test.go
+++ b/internal/database/badgerdb/badgerdb_test.go
@@ -27,7 +27,7 @@ func TestBatch(t *testing.T) {
 	mc := bdb.MaxBatchCount()
 	t.Logf("max batch count: %v", mc)
 	for i := int64(0); i < (mc*2)+3; i++ {
-		db.SetBatch(ctx, fmt.Sprintf("/%08v", i), []byte(fmt.Sprintf("%08v", i)))
+		db.Set(ctx, fmt.Sprintf("/%08v", i), []byte(fmt.Sprintf("%08v", i)), true)
 	}
 	if err := db.Close(ctx); err != nil {
 		t.Fatal(err)

--- a/internal/database/badgerdb/writebatch.go
+++ b/internal/database/badgerdb/writebatch.go
@@ -5,6 +5,8 @@
 package badgerdb
 
 import (
+	"slices"
+
 	"github.com/dgraph-io/badger/v4"
 )
 
@@ -25,9 +27,9 @@ func newWriteBatch(bdb *badger.DB) *writeBatch {
 }
 
 func (wb *writeBatch) set(key, value []byte) error {
-	v := make([]byte, len(value))
-	copy(v, value)
-	return wb.batch.Set(key, v)
+	k := slices.Clone(key)
+	v := slices.Clone(value)
+	return wb.batch.Set(k, v)
 }
 
 func (wb *writeBatch) flush() error {

--- a/internal/database/databases_test.go
+++ b/internal/database/databases_test.go
@@ -68,8 +68,6 @@ func populateDatabase(t *testing.T, db database.DB, nItems int) {
 }
 
 func validatePopulatedDatabase(t *testing.T, found []string, nItems int) {
-	fmt.Printf("N ITEMS: %v\n", nItems)
-	fmt.Printf("found: %v - %v\n", len(found), found)
 	n, p := 0, "a"
 	for i := 0; i < nItems*2; i++ {
 		k, v := fmt.Sprintf("/%v/%02v", p, n), fmt.Sprintf("%v%v", p, n)
@@ -122,7 +120,7 @@ func testScan(t *testing.T, factory databaseFactory) {
 	sort.Strings(found)
 	validatePopulatedDatabase(t, found, nItems)
 
-	// Scan can be ised to implement a range scan.
+	// Scan can be used to implement a range scan.
 	found = []string{}
 	err = db.Scan(ctx, "/z/03", func(_ context.Context, k string, v []byte) bool {
 		found = append(found, k+string(v))

--- a/internal/database/databases_test.go
+++ b/internal/database/databases_test.go
@@ -44,7 +44,7 @@ func populateDatabase(t *testing.T, db database.DB, nItems int) {
 	ctx := context.Background()
 	defer db.Close(ctx)
 	for i := 0; i < nItems; i++ {
-		if err := db.Set(ctx, fmt.Sprintf("/a/%02v", i), []byte(fmt.Sprintf("a%v", i))); err != nil {
+		if err := db.Set(ctx, fmt.Sprintf("/a/%02v", i), []byte(fmt.Sprintf("a%v", i)), false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -52,7 +52,7 @@ func populateDatabase(t *testing.T, db database.DB, nItems int) {
 	go func() {
 		defer close(ch)
 		for i := 0; i < nItems; i++ {
-			if err := db.SetBatch(ctx, fmt.Sprintf("/z/%02v", i), []byte(fmt.Sprintf("z%v", i))); err != nil {
+			if err := db.Set(ctx, fmt.Sprintf("/z/%02v", i), []byte(fmt.Sprintf("z%v", i)), true); err != nil {
 				ch <- err
 				return
 			}
@@ -68,6 +68,8 @@ func populateDatabase(t *testing.T, db database.DB, nItems int) {
 }
 
 func validatePopulatedDatabase(t *testing.T, found []string, nItems int) {
+	fmt.Printf("N ITEMS: %v\n", nItems)
+	fmt.Printf("found: %v - %v\n", len(found), found)
 	n, p := 0, "a"
 	for i := 0; i < nItems*2; i++ {
 		k, v := fmt.Sprintf("/%v/%02v", p, n), fmt.Sprintf("%v%v", p, n)
@@ -352,7 +354,7 @@ func testDelete(t *testing.T, factory databaseFactory) {
 		keys = append(keys, fmt.Sprintf("/%03v", i))
 	}
 	for _, k := range keys {
-		if err := db.Set(ctx, k, []byte(k)); err != nil {
+		if err := db.Set(ctx, k, []byte(k), false); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -369,28 +371,7 @@ func testDelete(t *testing.T, factory databaseFactory) {
 		return keys
 	}
 
-	left := []string{}
-	rmIdx := []int{27, 38, 41}
-	rmKeys := []string{}
-	for _, i := range rmIdx {
-		rmKeys = append(rmKeys, fmt.Sprintf("/%03v", i))
-	}
-
-	for i := 0; i < nItems; i++ {
-		if !slices.Contains(rmIdx, i) {
-			left = append(left, keys[i])
-		}
-	}
-
-	if err := db.Delete(ctx, rmKeys...); err != nil {
-		t.Fatal(err)
-	}
-
-	if got, want := scan(), left; !reflect.DeepEqual(got, want) {
-		t.Errorf("got %v, want %v", got, want)
-	}
-
-	left = slices.Delete(left, 10, 20)
+	left := slices.Delete(keys, 10, 20)
 	if err := db.DeletePrefix(ctx, "/01"); err != nil {
 		t.Fatal(err)
 	}
@@ -399,9 +380,10 @@ func testDelete(t *testing.T, factory databaseFactory) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	if err := db.Delete(ctx, "notthere"); err != nil {
+	if err := db.DeletePrefix(ctx, "notthere"); err != nil {
 		t.Fatal(err)
 	}
+
 }
 
 func TestExists(t *testing.T) {
@@ -414,12 +396,12 @@ func testExists(t *testing.T, factory databaseFactory) {
 	tmpdir := t.TempDir()
 	db := factory(t, tmpdir, prefix, false)
 	defer db.Close(ctx)
-
-	k, err := db.Get(ctx, "/a/b/c")
+	var buf bytes.Buffer
+	err := db.Get(ctx, "/a/b/c", &buf)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if k != nil {
+	if k := buf.Bytes(); k != nil {
 		t.Errorf("got %v, want nil", k)
 	}
 }

--- a/internal/database/ifc.go
+++ b/internal/database/ifc.go
@@ -42,9 +42,6 @@ type DB interface {
 	// its contents in the supplied bytes.Buffer.
 	Get(ctx context.Context, prefix string, buf *bytes.Buffer) error
 
-	// Delete deletes the specified entries.
-	//Delete(ctx context.Context, keys ...string) error
-
 	// DeletePrefix deletes all keys that have the specified prefix.
 	DeletePrefix(ctx context.Context, prefix string) error
 

--- a/internal/database/ifc.go
+++ b/internal/database/ifc.go
@@ -25,40 +25,31 @@ func WithTimeout[T any](t time.Duration) func(o *Options[T]) {
 }
 
 type Options[T any] struct {
-	ReadOnly bool
-	Timeout  time.Duration
-	Sub      T
+	ReadOnly  bool
+	Timeout   time.Duration
+	Hardlinks bool
+	Sub       T
 }
 
 // DB represents a database.
 type DB interface {
-	// Set stores the value associated with key.
-	Set(ctx context.Context, key string, value []byte) error
+	// Set stores the value associated with prefix. If batch is true then
+	// calls from multiple goroutines may be merged together. This is only
+	// useful when Set is called from multiple goroutines.
+	Set(ctx context.Context, prefix string, value []byte, batch bool) error
 
-	// Get retrieves the value associated with key.
-	Get(ctx context.Context, key string) ([]byte, error)
-
-	// GeGetBuft retrieves the value associated with key storing
+	// Get retrieves the value associated with prefix storing
 	// its contents in the supplied bytes.Buffer.
-	GetBuf(ctx context.Context, key string, buf *bytes.Buffer) error
+	Get(ctx context.Context, prefix string, buf *bytes.Buffer) error
 
 	// Delete deletes the specified entries.
-	Delete(ctx context.Context, keys ...string) error
+	//Delete(ctx context.Context, keys ...string) error
 
 	// DeletePrefix deletes all keys that have the specified prefix.
 	DeletePrefix(ctx context.Context, prefix string) error
 
 	// DeleteErrors deletes all errors that have the specified prefix.
 	DeleteErrors(ctx context.Context, prefix string) error
-
-	SaveStats(ctx context.Context, when time.Time, value []byte) error
-	LastStats(ctx context.Context) (time.Time, []byte, error)
-	VisitStats(ctx context.Context, start, stop time.Time,
-		visitor func(ctx context.Context, when time.Time, value []byte) bool) error
-
-	// SetBatch is like Set but allows for batching of concurrent calls to
-	// SetBatch. It should only be used when called from multiple goroutines.
-	SetBatch(ctx context.Context, key string, buf []byte) error
 
 	// Scan can be used to iterate over all keys in the database starting at
 	// the specified key.
@@ -90,7 +81,7 @@ type DB interface {
 	VisitErrors(ctx context.Context, key string, visitor func(ctx context.Context, key string, when time.Time, val []byte) bool) error
 
 	// Clear clears all of the log or error entries.
-	Clear(ctx context.Context, logs, errors, stats bool) error
+	Clear(ctx context.Context, logs, errors bool) error
 
 	// Close closes the database.
 	Close(context.Context) error

--- a/internal/prefixinfo/devino_darwin.go
+++ b/internal/prefixinfo/devino_darwin.go
@@ -20,6 +20,6 @@ func devino(fi file.Info) (uint64, uint64, bool) {
 	return uint64(st.Dev), st.Ino, true
 }
 
-func syscallStat(uid, gid uint32, dev, ino uint64) any {
+func SysInfo(uid, gid uint32, dev, ino uint64) any {
 	return &syscall.Stat_t{Uid: uid, Gid: gid, Dev: int32(dev), Ino: ino}
 }

--- a/internal/prefixinfo/devino_darwin.go
+++ b/internal/prefixinfo/devino_darwin.go
@@ -19,3 +19,7 @@ func devino(fi file.Info) (uint64, uint64, bool) {
 	}
 	return uint64(st.Dev), st.Ino, true
 }
+
+func syscallStat(uid, gid uint32, dev, ino uint64) any {
+	return &syscall.Stat_t{Uid: uid, Gid: gid, Dev: int32(dev), Ino: ino}
+}

--- a/internal/prefixinfo/devino_darwin.go
+++ b/internal/prefixinfo/devino_darwin.go
@@ -1,0 +1,21 @@
+// Copyright 2023 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+//go:build darwin
+
+package prefixinfo
+
+import (
+	"syscall"
+
+	"cloudeng.io/file"
+)
+
+func devino(fi file.Info) (uint64, uint64, bool) {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+	return uint64(st.Dev), st.Ino, true
+}

--- a/internal/prefixinfo/devino_linux.go
+++ b/internal/prefixinfo/devino_linux.go
@@ -1,0 +1,21 @@
+// Copyright 2023 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+//go:build linux
+
+package prefixinfo
+
+import (
+	"syscall"
+
+	"cloudeng.io/file"
+)
+
+func devino(fi file.Info) (uint64, uint64, bool) {
+	st, ok := fi.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, 0, false
+	}
+	return st.Dev, st.Ino, true
+}

--- a/internal/prefixinfo/devino_linux.go
+++ b/internal/prefixinfo/devino_linux.go
@@ -20,6 +20,6 @@ func devino(fi file.Info) (uint64, uint64, bool) {
 	return st.Dev, st.Ino, true
 }
 
-func syscallStat(uid, gid uint32, dev, ino uint64) any {
+func SysInfo(uid, gid uint32, dev, ino uint64) any {
 	return &syscall.Stat_t{Uid: uid, Gid: gid, Dev: dev, Ino: ino}
 }

--- a/internal/prefixinfo/devino_linux.go
+++ b/internal/prefixinfo/devino_linux.go
@@ -19,3 +19,7 @@ func devino(fi file.Info) (uint64, uint64, bool) {
 	}
 	return st.Dev, st.Ino, true
 }
+
+func syscallStat(uid, gid uint32, dev, ino uint64) any {
+	return &syscall.Stat_t{Uid: uid, Gid: gid, Dev: dev, Ino: ino}
+}

--- a/internal/prefixinfo/devino_windows.go
+++ b/internal/prefixinfo/devino_windows.go
@@ -14,6 +14,6 @@ func devino(fi file.Info) (uint64, uint64) {
 	return 0, 0, false
 }
 
-func syscallStat(uid, gid uint32, dev, ino uint64) any {
-	return &userInfo{uid: uid, gid: gid}
+func SysInfo(uid, gid uint32, dev, ino uint64) any {
+	return &sysinfo{uid: uid, gid: gid, dev: dev, ino: ino}
 }

--- a/internal/prefixinfo/devino_windows.go
+++ b/internal/prefixinfo/devino_windows.go
@@ -6,8 +6,14 @@
 
 package prefixinfo
 
-import "cloudeng.io/file"
+import (
+	"cloudeng.io/file"
+)
 
 func devino(fi file.Info) (uint64, uint64) {
 	return 0, 0, false
+}
+
+func syscallStat(uid, gid uint32, dev, ino uint64) any {
+	return &userInfo{uid: uid, gid: gid}
 }

--- a/internal/prefixinfo/devino_windows.go
+++ b/internal/prefixinfo/devino_windows.go
@@ -1,0 +1,13 @@
+// Copyright 2023 cloudeng llc. All rights reserved.
+// Use of this source code is governed by the Apache-2.0
+// license that can be found in the LICENSE file.
+
+//go:build windows
+
+package prefixinfo
+
+import "cloudeng.io/file"
+
+func devino(fi file.Info) (uint64, uint64) {
+	return 0, 0, false
+}

--- a/internal/prefixinfo/devino_windows.go
+++ b/internal/prefixinfo/devino_windows.go
@@ -15,5 +15,5 @@ func devino(fi file.Info) (uint64, uint64, bool) {
 }
 
 func SysInfo(uid, gid uint32, dev, ino uint64) any {
-	return &sysinfo{uid: uid, gid: gid}
+	return &sysInfo{uid: uid, gid: gid}
 }

--- a/internal/prefixinfo/devino_windows.go
+++ b/internal/prefixinfo/devino_windows.go
@@ -15,5 +15,5 @@ func devino(fi file.Info) (uint64, uint64, bool) {
 }
 
 func SysInfo(uid, gid uint32, dev, ino uint64) any {
-	return &sysinfo{uid: uid, gid: gid, dev: dev, ino: ino}
+	return &sysinfo{uid: uid, gid: gid}
 }

--- a/internal/prefixinfo/devino_windows.go
+++ b/internal/prefixinfo/devino_windows.go
@@ -10,8 +10,8 @@ import (
 	"cloudeng.io/file"
 )
 
-func devino(fi file.Info) (uint64, uint64) {
-	return 0, 0, false
+func devino(fi file.Info) (uint64, uint64, bool) {
+	return 0, 0, true
 }
 
 func SysInfo(uid, gid uint32, dev, ino uint64) any {

--- a/internal/prefixinfo/idmap_test.go
+++ b/internal/prefixinfo/idmap_test.go
@@ -99,7 +99,7 @@ func TestCreateIDMaps(t *testing.T) {
 	modTime := time.Now().Truncate(0)
 
 	var uid, gid uint32 = 100, 1
-	ug00, ug10, ug01, ug11, ugOther := TestdataIDCombinationsFiles(modTime, uid, gid)
+	ug00, ug10, ug01, ug11, ugOther := TestdataIDCombinationsFiles(modTime, uid, gid, 0)
 
 	for i, tc := range []struct {
 		fi                   []file.Info
@@ -125,7 +125,7 @@ func TestCreateIDMaps(t *testing.T) {
 			[]uint32{uid + 1, uid + 1}, []uint32{gid + 1, gid + 1},
 			[]uint32{uid + 1, uid + 1}, []uint32{gid + 1, gid + 1}},
 	} {
-		info := file.NewInfo("dir", 1, 0700, time.Now().Truncate(0), SysUserGroupID(uid, gid))
+		info := TestdataNewInfo("dir", 1, 0700, time.Now().Truncate(0), uid, gid, 0, 0)
 		pi, err := New(info)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/prefixinfo/internal_test.go
+++ b/internal/prefixinfo/internal_test.go
@@ -111,3 +111,19 @@ func IDsFromStats(s StatsList) []uint32 {
 	}
 	return r
 }
+
+func SetDevInode(pi *T, dev, ino uint64) {
+	pi.device = dev
+	pi.inodes = make([]uint64, len(pi.entries))
+	for i := range pi.entries {
+		pi.inodes[i] = ino + uint64(i)
+	}
+}
+
+func GetDev(pi T) uint64 {
+	return pi.device
+}
+
+func GetInodes(pi T) []uint64 {
+	return pi.inodes
+}

--- a/internal/prefixinfo/internal_test.go
+++ b/internal/prefixinfo/internal_test.go
@@ -59,44 +59,44 @@ func BinaryRoundTrip(t *testing.T, pi *T) T {
 // ug01 has uid, gid+1 for the second file
 // ug11 has uid+1, gid+1 for the second file
 // ugOther has uid+1, gid+1 for both files
-func TestdataIDCombinations(modTime time.Time, mode fs.FileMode, uid, gid uint32) (ug00, ug10, ug01, ug11, ugOther []file.Info) {
+func TestdataIDCombinations(modTime time.Time, mode fs.FileMode, uid, gid uint32, inode uint64) (ug00, ug10, ug01, ug11, ugOther []file.Info) {
 	ug00 = []file.Info{
-		TestdataNewInfo("0", 1, mode, modTime, uid, gid),
-		TestdataNewInfo("1", 2, mode, modTime, uid, gid),
+		TestdataNewInfo("0", 1, mode, modTime, uid, gid, 0, inode),
+		TestdataNewInfo("1", 2, mode, modTime, uid, gid, 0, inode),
 	}
 	ug10 = []file.Info{
-		TestdataNewInfo("0", 1, mode, modTime, uid, gid),
-		TestdataNewInfo("1", 2, mode, modTime, uid+1, gid),
+		TestdataNewInfo("0", 1, mode, modTime, uid, gid, 0, inode),
+		TestdataNewInfo("1", 2, mode, modTime, uid+1, gid, 0, inode),
 	}
 	ug01 = []file.Info{
-		TestdataNewInfo("0", 1, mode, modTime, uid, gid),
-		TestdataNewInfo("1", 2, mode, modTime, uid, gid+1),
+		TestdataNewInfo("0", 1, mode, modTime, uid, gid, 0, inode),
+		TestdataNewInfo("1", 2, mode, modTime, uid, gid+1, 0, inode),
 	}
 	ug11 = []file.Info{
-		TestdataNewInfo("0", 1, mode, modTime, uid, gid),
-		TestdataNewInfo("1", 2, mode, modTime, uid+1, gid+1),
+		TestdataNewInfo("0", 1, mode, modTime, uid, gid, 0, inode),
+		TestdataNewInfo("1", 2, mode, modTime, uid+1, gid+1, 0, inode),
 	}
 	ugOther = []file.Info{
-		TestdataNewInfo("0", 1, mode, modTime, uid+1, gid+1),
-		TestdataNewInfo("1", 2, mode, modTime, uid+1, gid+1),
+		TestdataNewInfo("0", 1, mode, modTime, uid+1, gid+1, 0, inode),
+		TestdataNewInfo("1", 2, mode, modTime, uid+1, gid+1, 0, inode),
 	}
 	return
 }
 
-func TestdataIDCombinationsFiles(modTime time.Time, uid, gid uint32) (ug00, ug10, ug01, ug11, ugOther []file.Info) {
-	return TestdataIDCombinations(modTime, 0700, uid, gid)
+func TestdataIDCombinationsFiles(modTime time.Time, uid, gid uint32, inode uint64) (ug00, ug10, ug01, ug11, ugOther []file.Info) {
+	return TestdataIDCombinations(modTime, 0700, uid, gid, inode)
 }
 
-func TestdataIDCombinationsDirs(modTime time.Time, uid, gid uint32) (ug00, ug10, ug01, ug11, ugOther []file.Info) {
-	return TestdataIDCombinations(modTime, 0700|os.ModeDir, uid, gid)
+func TestdataIDCombinationsDirs(modTime time.Time, uid, gid uint32, inode uint64) (ug00, ug10, ug01, ug11, ugOther []file.Info) {
+	return TestdataIDCombinations(modTime, 0700|os.ModeDir, uid, gid, inode)
 }
 
-func TestdataNewInfo(name string, size int64, mode fs.FileMode, modTime time.Time, uid, gid uint32) file.Info {
-	return file.NewInfo(name, size, mode, modTime, SysUserGroupID(uid, gid))
+func TestdataNewInfo(name string, size int64, mode fs.FileMode, modTime time.Time, uid, gid uint32, device, inode uint64) file.Info {
+	return file.NewInfo(name, size, mode, modTime, syscallStat(uid, gid, device, inode))
 }
 
-func TestdataNewPrefixInfo(t *testing.T, name string, size int64, mode fs.FileMode, modTime time.Time, uid, gid uint32) T {
-	fi := TestdataNewInfo(name, size, mode, modTime, uid, gid)
+func TestdataNewPrefixInfo(t *testing.T, name string, size int64, mode fs.FileMode, modTime time.Time, uid, gid uint32, dev, inode uint64) T {
+	fi := TestdataNewInfo(name, size, mode, modTime, uid, gid, dev, inode)
 	pi, err := New(fi)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/prefixinfo/internal_test.go
+++ b/internal/prefixinfo/internal_test.go
@@ -92,7 +92,7 @@ func TestdataIDCombinationsDirs(modTime time.Time, uid, gid uint32, inode uint64
 }
 
 func TestdataNewInfo(name string, size int64, mode fs.FileMode, modTime time.Time, uid, gid uint32, device, inode uint64) file.Info {
-	return file.NewInfo(name, size, mode, modTime, syscallStat(uid, gid, device, inode))
+	return file.NewInfo(name, size, mode, modTime, SysInfo(uid, gid, device, inode))
 }
 
 func TestdataNewPrefixInfo(t *testing.T, name string, size int64, mode fs.FileMode, modTime time.Time, uid, gid uint32, dev, inode uint64) T {
@@ -110,20 +110,4 @@ func IDsFromStats(s StatsList) []uint32 {
 		r = append(r, st.ID)
 	}
 	return r
-}
-
-func SetDevInode(pi *T, dev, ino uint64) {
-	pi.device = dev
-	pi.inodes = make([]uint64, len(pi.entries))
-	for i := range pi.entries {
-		pi.inodes[i] = ino + uint64(i)
-	}
-}
-
-func GetDev(pi T) uint64 {
-	return pi.device
-}
-
-func GetInodes(pi T) []uint64 {
-	return pi.inodes
 }

--- a/internal/prefixinfo/prefixinfo.go
+++ b/internal/prefixinfo/prefixinfo.go
@@ -123,6 +123,19 @@ func (pi T) PrefixesOnly() file.InfoList {
 	return fi
 }
 
+// Device returns the id for the underlying storage device for this prefix
+// and all of its children.
+func (pi T) Device() uint64 {
+	return pi.device
+}
+
+// Inodes returns the inodes for the contents of this prefix. It can
+// only be called after Finalize() has been called or after unmarshaling
+// a previously finalized PrefixInfo.
+func (pi T) Inodes() []uint64 {
+	return pi.inodes
+}
+
 func (pi *T) MarshalBinary() ([]byte, error) {
 	var buf bytes.Buffer
 	buf.Grow(1000)

--- a/internal/prefixinfo/prefixinfo_test.go
+++ b/internal/prefixinfo/prefixinfo_test.go
@@ -91,7 +91,6 @@ func cmpInfoList(t *testing.T, npi prefixinfo.T, got, want file.InfoList) {
 		if got, want := g.Mode(), want[i].Mode(); got != want {
 			t.Errorf("got %v, want %v", got, want)
 		}
-
 	}
 }
 
@@ -117,6 +116,11 @@ func TestBinaryEncoding(t *testing.T) {
 		if err := pi.Finalize(); err != nil {
 			t.Fatal(err)
 		}
+		expectedInodes := make([]uint64, len(tc.fi))
+		for i := range tc.fi {
+			expectedInodes[i] = uint64(100 + i)
+		}
+		prefixinfo.SetDevInode(&pi, 33, 100)
 		for _, fn := range []prefixinfo.RoundTripper{
 			prefixinfo.GobRoundTrip, prefixinfo.BinaryRoundTrip,
 		} {
@@ -151,6 +155,12 @@ func TestBinaryEncoding(t *testing.T) {
 
 			scanAndMatchGroups(t, &pi, gid+1, tc.gid1s)
 
+			if got, want := prefixinfo.GetDev(npi), uint64(33); got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+			if got, want := prefixinfo.GetInodes(npi), expectedInodes; !slices.Equal(got, want) {
+				t.Errorf("got %v, want %v", got, want)
+			}
 		}
 	}
 }

--- a/internal/prefixinfo/prefixinfo_test.go
+++ b/internal/prefixinfo/prefixinfo_test.go
@@ -116,7 +116,8 @@ func TestBinaryEncoding(t *testing.T) {
 		if err := pi.Finalize(); err != nil {
 			t.Fatal(err)
 		}
-		expectedInodes := prefixinfo.GetInodes(pi)
+		expectedDevice := pi.Device()
+		expectedInodes := pi.Inodes()
 		for _, fn := range []prefixinfo.RoundTripper{
 			prefixinfo.GobRoundTrip, prefixinfo.BinaryRoundTrip,
 		} {
@@ -151,10 +152,10 @@ func TestBinaryEncoding(t *testing.T) {
 
 			scanAndMatchGroups(t, &pi, gid+1, tc.gid1s)
 
-			if got, want := prefixinfo.GetDev(npi), uint64(33); got != want {
+			if got, want := npi.Device(), expectedDevice; got != want {
 				t.Errorf("got %v, want %v", got, want)
 			}
-			if got, want := prefixinfo.GetInodes(npi), expectedInodes; !slices.Equal(got, want) {
+			if got, want := npi.Inodes(), expectedInodes; !slices.Equal(got, want) {
 				t.Errorf("got %v, want %v", got, want)
 			}
 		}

--- a/internal/prefixinfo/userinfo.go
+++ b/internal/prefixinfo/userinfo.go
@@ -26,11 +26,11 @@ func (pi *T) UserGroupInfo(fi file.Info) (userID, groupID uint32) {
 	return u, g
 }
 
-func (pi *T) SetUserGroupFile(fi *file.Info, userID, groupID uint32) {
+func (pi *T) SetUserInfo(fi *file.Info, userID, groupID uint32) {
 	if pi.userID == userID && pi.groupID == groupID {
 		fi.SetSys(nil)
 	}
-	fi.SetSys(userinfo{userID, groupID})
+	fi.SetSys(userinfo{uid: userID, gid: groupID})
 }
 
 func UserGroup(fi file.Info) (userID, groupID uint32, ok bool) {

--- a/internal/prefixinfo/userinfo_test.go
+++ b/internal/prefixinfo/userinfo_test.go
@@ -44,7 +44,7 @@ func TestUserInfo(t *testing.T) {
 		t.Errorf("got %v, want %v", got, want)
 	}
 
-	pi.SetUserGroupFile(&fi, 600, 6)
+	pi.SetUserInfo(&fi, 600, 6)
 
 	uid, gid = pi.UserGroupInfo(fi)
 	if got, want := uid, uint32(600); got != want {

--- a/internal/prefixinfo/userinfo_unix.go
+++ b/internal/prefixinfo/userinfo_unix.go
@@ -18,7 +18,3 @@ func userGroupID(fi file.Info) (userID, groupID uint32, ok bool) {
 	}
 	return 0, 0, false
 }
-
-func SysUserGroupID(uid, gid uint32) any {
-	return &syscall.Stat_t{Uid: uid, Gid: gid}
-}

--- a/internal/prefixinfo/userinfo_windows.go
+++ b/internal/prefixinfo/userinfo_windows.go
@@ -15,7 +15,7 @@ type sysInfo struct {
 }
 
 func userGroupID(fi file.Info) (userID, groupID uint32, ok bool) {
-	if u, ok := fi.Sys().(*userInfo); ok {
+	if u, ok := fi.Sys().(*sysInfo); ok {
 		return u.uid, u.gid, true
 	}
 	// TODO: implement user/group in some form for windows, for now just

--- a/internal/prefixinfo/userinfo_windows.go
+++ b/internal/prefixinfo/userinfo_windows.go
@@ -10,7 +10,7 @@ import (
 	"cloudeng.io/file"
 )
 
-type userInfo struct {
+type sysInfo struct {
 	uid, gid uint32
 }
 

--- a/internal/prefixinfo/userinfo_windows.go
+++ b/internal/prefixinfo/userinfo_windows.go
@@ -22,7 +22,3 @@ func userGroupID(fi file.Info) (userID, groupID uint32, ok bool) {
 	// pretend that the user and group are 0
 	return 0, 0, true
 }
-
-func SysUserGroupID(uid, gid uint32) any {
-	return &userInfo{uid: uid, gid: gid}
-}

--- a/internal/reports/report_stats_test.go
+++ b/internal/reports/report_stats_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func newInfo(name string, size int64, mode fs.FileMode, modTime time.Time, uid, gid uint32) file.Info {
-	return file.NewInfo(name, size, mode, modTime, prefixinfo.SysUserGroupID(uid, gid))
+	return file.NewInfo(name, size, mode, modTime, prefixinfo.SysInfo(uid, gid, 0, 0))
 }
 
 func createPrefixInfo(t *testing.T, uid, gid uint32, name string, contents ...[]file.Info) prefixinfo.T {

--- a/internal/scandb.go
+++ b/internal/scandb.go
@@ -176,7 +176,7 @@ func (sdb *scanDB) GetPrefixInfo(ctx context.Context, key string, pi *prefixinfo
 	buf := bufPool.Get().(*bytes.Buffer)
 	buf.Reset()
 	defer bufPool.Put(buf)
-	if err := sdb.db.GetBuf(ctx, key, buf); err != nil {
+	if err := sdb.db.Get(ctx, key, buf); err != nil {
 		return false, err
 	}
 	if len(buf.Bytes()) == 0 {
@@ -190,7 +190,6 @@ func (sdb *scanDB) SetPrefixInfo(ctx context.Context, key string, unchanged bool
 	if unchanged {
 		return nil
 	}
-
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
@@ -202,7 +201,7 @@ func (sdb *scanDB) SetPrefixInfo(ctx context.Context, key string, unchanged bool
 	if err := pi.AppendBinary(buf); err != nil {
 		return err
 	}
-	return sdb.db.SetBatch(ctx, key, buf.Bytes())
+	return sdb.db.Set(ctx, key, buf.Bytes(), true)
 }
 
 func (sdb *scanDB) Close(ctx context.Context) error {

--- a/ls.go
+++ b/ls.go
@@ -35,7 +35,7 @@ func (l *lister) errors(ctx context.Context, values interface{}, args []string) 
 	}
 	defer db.Close(ctx)
 	if ef.Erase {
-		return db.Clear(ctx, false, true, false)
+		return db.Clear(ctx, false, true)
 	}
 
 	return db.VisitErrors(ctx, args[0],
@@ -54,7 +54,7 @@ func (l *lister) logs(ctx context.Context, values interface{}, args []string) er
 	defer db.Close(ctx)
 
 	if lf.Erase {
-		return db.Clear(ctx, false, true, false)
+		return db.Clear(ctx, false, true)
 	}
 
 	from, to, _, err := lf.TimeRangeFlags.FromTo()

--- a/main.go
+++ b/main.go
@@ -86,10 +86,7 @@ commands:
         arguments:
           - <filename>
 
-      - name: extract-from-db
-        summary: extract the statistics stored in the database and save them to a file.
-        arguments:
-          - <prefix>
+
   - name: reports
     summary: generate and manage reports.
     commands:
@@ -151,7 +148,6 @@ func cli() *subcmd.CommandSetYAML {
 	cmdSet.Set("stats", "compute").MustRunner(statsCmd.compute, &computeFlags{})
 
 	cmdSet.Set("stats", "view").MustRunner(statsCmd.view, &viewFlags{})
-	cmdSet.Set("stats", "extract-from-db").MustRunner(statsCmd.extract, &extractFlags{})
 
 	reportsCmds := &reportCmds{}
 	cmdSet.Set("reports", "generate").MustRunner(reportsCmds.generate, &reportsFlags{})

--- a/stats.go
+++ b/stats.go
@@ -81,10 +81,6 @@ type viewFlags struct {
 	Info  bool   `subcmd:"info,false,display metadata for the stats file"`
 }
 
-type extractFlags struct {
-	StatsDir string `subcmd:"stats-dir,stats,'directory that stats files are written to'"`
-}
-
 func (st *statsCmds) compute(ctx context.Context, values interface{}, args []string) error {
 	cf := values.(*computeFlags)
 

--- a/stats.go
+++ b/stats.go
@@ -121,36 +121,6 @@ func (st *statsCmds) compute(ctx context.Context, values interface{}, args []str
 	return saveStats(cf.StatsDir, stats)
 }
 
-func (st *statsCmds) extract(ctx context.Context, values interface{}, args []string) error {
-	ef := values.(*extractFlags)
-	ctx, _, db, err := internal.OpenPrefixAndDatabase(ctx, globalConfig, args[0], true)
-	if err != nil {
-		return err
-	}
-	defer db.Close(ctx)
-
-	var from time.Time
-	to := time.Now()
-	return db.VisitStats(ctx, from, to,
-		func(_ context.Context, when time.Time, detail []byte) bool {
-			var sdb reports.AllStats
-			if err := gob.NewDecoder(bytes.NewBuffer(detail)).Decode(&sdb); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to decode stats for %v: %v\n", when, err)
-				return false
-			}
-			stats := statsFileFormat{
-				Prefix:     args[0],
-				Date:       when,
-				Expression: "",
-				Stats:      &sdb,
-			}
-			if err := saveStats(ef.StatsDir, stats); err != nil {
-				fmt.Fprintf(os.Stderr, "failed to save stats for %v: %v\n", when, err)
-			}
-			return true
-		})
-}
-
 func (st *statsCmds) computeStats(ctx context.Context, db database.DB, expr boolexpr.T, prefix string, calc diskusage.Calculator, topN int, progress bool) (*reports.AllStats, error) {
 
 	hasStorabeBytes := calc.String() != "identity"


### PR DESCRIPTION
This PR simplifies the database interface and implementation by using single-byte prefixes for 'buckets'. It also removes the no longer used Stats methods. These changes mean that the database must be rebuilt.