### PR TITLE
rework stats, matcher, correctly count directory sizes, hardlinks etc.

### DIFF
--- a/internal/boolexpr/expression.go
+++ b/internal/boolexpr/expression.go
@@ -136,7 +136,7 @@ func createExpr(p *boolexpr.Parser, args []string) (boolexpr.T, bool, error) {
 }
 
 func CreateMatcher(parser *boolexpr.Parser, opts ...Option) (Matcher, error) {
-	m := match{}
+	m := Matcher{}
 	for _, fn := range opts {
 		fn(&m.options)
 	}
@@ -146,26 +146,26 @@ func CreateMatcher(parser *boolexpr.Parser, opts ...Option) (Matcher, error) {
 	var err error
 	m.expr, m.exprSet, err = createExpr(parser, m.entry)
 	if err != nil {
-		return match{}, err
+		return Matcher{}, err
 	}
 	return m, nil
 }
 
-type match struct {
+type Matcher struct {
 	options
 	exprSet bool
 	expr    boolexpr.T
 	hl      *hardlinks.Incremental
 }
 
-func (m match) IsHardlink(xattr file.XAttr) bool {
+func (m Matcher) IsHardlink(xattr file.XAttr) bool {
 	if m.hl == nil {
 		return false
 	}
 	return m.hl.Ref(xattr.Device, xattr.FileID)
 }
 
-func (m match) Prefix(prefix string, pi *prefixinfo.T) bool {
+func (m Matcher) Prefix(prefix string, pi *prefixinfo.T) bool {
 	if !m.exprSet {
 		return m.emptyEntryValue
 	}
@@ -176,7 +176,7 @@ func (m match) Prefix(prefix string, pi *prefixinfo.T) bool {
 	return m.expr.Eval(prefixWithName{T: pi, name: name, path: prefix})
 }
 
-func (m match) Entry(prefix string, pi *prefixinfo.T, fi file.Info) bool {
+func (m Matcher) Entry(prefix string, pi *prefixinfo.T, fi file.Info) bool {
 	if !m.exprSet {
 		return m.emptyEntryValue
 	}
@@ -187,7 +187,7 @@ func (m match) Entry(prefix string, pi *prefixinfo.T, fi file.Info) bool {
 	return m.expr.Eval(entryWithXattr{pi: pi, fi: fi, path: path})
 }
 
-func (m match) String() string {
+func (m Matcher) String() string {
 	ph := "[hardlink handling disabled]:"
 	if m.hl != nil {
 		ph = "[hardlink handling enabled]:"
@@ -242,11 +242,4 @@ func (pi prefixWithName) NumEntries() int64 {
 func AlwaysMatch(p *boolexpr.Parser) Matcher {
 	m, _ := CreateMatcher(p, WithEmptyEntryValue(true))
 	return m
-}
-
-type Matcher interface {
-	IsHardlink(xattr file.XAttr) bool
-	Entry(prefix string, info *prefixinfo.T, fi file.Info) bool
-	Prefix(prefix string, info *prefixinfo.T) bool
-	String() string
 }

--- a/internal/boolexpr/expression.go
+++ b/internal/boolexpr/expression.go
@@ -158,11 +158,10 @@ type match struct {
 	hl      *hardlinks.Incremental
 }
 
-func (m match) IsHardlink(prefix string, info *prefixinfo.T, fi file.Info) bool {
+func (m match) IsHardlink(xattr file.XAttr) bool {
 	if m.hl == nil {
 		return false
 	}
-	xattr := info.XAttrInfo(fi)
 	return m.hl.Ref(xattr.Device, xattr.FileID)
 }
 
@@ -240,26 +239,13 @@ func (pi prefixWithName) NumEntries() int64 {
 	return int64(len(pi.T.InfoList()))
 }
 
-type AlwaysMatch struct{}
-
-func (AlwaysMatch) IsHardlink(prefix string, info *prefixinfo.T, fi file.Info) bool {
-	return false
-}
-
-func (AlwaysMatch) Entry(prefix string, info *prefixinfo.T, fi file.Info) bool {
-	return true
-}
-
-func (AlwaysMatch) Prefix(prefix string, info *prefixinfo.T) bool {
-	return true
-}
-
-func (AlwaysMatch) String() string {
-	return "always match"
+func AlwaysMatch(p *boolexpr.Parser) Matcher {
+	m, _ := CreateMatcher(p, WithEmptyEntryValue(true))
+	return m
 }
 
 type Matcher interface {
-	IsHardlink(prefix string, info *prefixinfo.T, fi file.Info) bool
+	IsHardlink(xattr file.XAttr) bool
 	Entry(prefix string, info *prefixinfo.T, fi file.Info) bool
 	Prefix(prefix string, info *prefixinfo.T) bool
 	String() string

--- a/internal/hardlinks/hardlinks.go
+++ b/internal/hardlinks/hardlinks.go
@@ -4,12 +4,12 @@
 
 package hardlinks
 
-type perDevice[T any] struct {
+type perDevice[T comparable] struct {
 	dev    uint64
 	inodes map[uint64]T
 }
 
-type devices[T any] []*perDevice[T]
+type devices[T comparable] []*perDevice[T]
 
 func (d devices[T]) forDevice(dev uint64) (devices[T], *perDevice[T]) {
 	for _, pd := range d {
@@ -40,23 +40,4 @@ func (i *Incremental) Ref(dev uint64, ino uint64) bool {
 	}
 	pd.inodes[ino] = struct{}{}
 	return false
-}
-
-type Catalog struct {
-	devices devices[[]string]
-}
-
-func (i *Catalog) Ref(dev uint64, ino uint64, name string) {
-	_, pd := i.devices.forDevice(dev)
-	pd.inodes[ino] = append(pd.inodes[ino], name)
-}
-
-func (i *Catalog) Visit(fn func(dev uint64, ino uint64, names []string)) {
-	for _, pd := range i.devices {
-		for ino, names := range pd.inodes {
-			if len(names) > 1 {
-				fn(pd.dev, ino, names)
-			}
-		}
-	}
 }

--- a/markdown.go
+++ b/markdown.go
@@ -13,14 +13,21 @@ import (
 
 	"cloudeng.io/cmd/idu/internal/reports"
 	"cloudeng.io/cmd/idu/internal/usernames"
+	"cloudeng.io/file/diskusage"
 	"golang.org/x/exp/maps"
 )
 
 func tpl(name string) *template.Template {
 	return template.New(name).Funcs(template.FuncMap{
-		"fmtBytes": fmtSize,
-		"fmtCount": fmtCount,
+		"fmtBytes":   fmtSize,
+		"fmtKiBytes": fmtKiBytes,
+		"fmtCount":   fmtCount,
 	})
+}
+
+func fmtKiBytes(size int64) string {
+	size /= int64(diskusage.KiB)
+	return printer.Sprintf("%v KiB", size)
 }
 
 const mdTOC = `
@@ -40,8 +47,8 @@ const mdTotals = `
 
 | Metric | Value |
 | :--- | ---: |
-| Bytes | {{fmtBytes .Heaps.TotalBytes}} |
-| Storage Bytes | {{fmtBytes .Heaps.TotalStorageBytes}} |
+| Bytes | {{fmtBytes .Heaps.TotalBytes}} ({{fmtKiBytes .Heaps.TotalBytes}}) |
+| Storage Bytes | {{fmtBytes .Heaps.TotalStorageBytes}} ({{fmtKiBytes .Heaps.TotalStorageBytes}}) |
 | Files | {{fmtCount .Heaps.TotalFiles }} |
 | Prefixes | {{fmtCount .Heaps.TotalPrefixes}} |
 | Prefixes + Files | {{fmtCount .TotalPrefixesAndFiles}} |

--- a/stats.go
+++ b/stats.go
@@ -149,10 +149,8 @@ func (st *statsCmds) computeStats(ctx context.Context, db database.DB, match boo
 			fmt.Fprintf(os.Stderr, "failed to unmarshal value for %v: %v\n", k, err)
 			return
 		}
-		//entryMatcher := match
 		if !match.Prefix(k, &pi) {
 			return
-			//entryMatcher = boolexpr.AlwaysMatch{}
 		}
 		if err := sdb.Update(k, pi, calc, match); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to compute stats for %v: %v\n", k, err)

--- a/stats.go
+++ b/stats.go
@@ -114,7 +114,7 @@ func (st *statsCmds) computeFS(ctx context.Context, fwfs filewalk.FS, cf *comput
 		boolexpr.WithEntryExpression(args[1:]...),
 		boolexpr.WithEmptyEntryValue(true),
 		boolexpr.WithFilewalkFS(fwfs),
-		boolexpr.WithHardlinkHandling(cfg.CountHardlinkAsFiles))
+		boolexpr.WithHardlinkHandling(!cfg.CountHardlinkAsFiles))
 	if err != nil {
 		return err
 	}
@@ -137,11 +137,8 @@ func (st *statsCmds) computeFS(ctx context.Context, fwfs filewalk.FS, cf *comput
 }
 
 func (st *statsCmds) computeStats(ctx context.Context, db database.DB, match boolexpr.Matcher, prefix string, calc diskusage.Calculator, topN int, progress bool) (*reports.AllStats, error) {
-
-	hasStorabeBytes := calc.String() != "identity"
-	sdb := reports.NewAllStats(prefix, hasStorabeBytes, topN)
+	sdb := reports.NewAllStats(prefix, topN)
 	n := 0
-
 	err := db.Stream(ctx, prefix, func(_ context.Context, k string, v []byte) {
 		if progress && (n != 0 && n%1000 == 0) {
 			fmt.Printf("processed % 10v entries\n", fmtCount(int64(n)))
@@ -152,11 +149,12 @@ func (st *statsCmds) computeStats(ctx context.Context, db database.DB, match boo
 			fmt.Fprintf(os.Stderr, "failed to unmarshal value for %v: %v\n", k, err)
 			return
 		}
-		entryMatcher := match
-		if match.Prefix(k, &pi) {
-			entryMatcher = boolexpr.AlwaysMatch{}
+		//entryMatcher := match
+		if !match.Prefix(k, &pi) {
+			return
+			//entryMatcher = boolexpr.AlwaysMatch{}
 		}
-		if err := sdb.Update(k, pi, calc, entryMatcher); err != nil {
+		if err := sdb.Update(k, pi, calc, match); err != nil {
 			fmt.Fprintf(os.Stderr, "failed to compute stats for %v: %v\n", k, err)
 			return
 		}
@@ -245,10 +243,8 @@ func (hf heapFormatter[T]) formatHeap(heap *heap.MinMax[int64, T], out io.Writer
 func (hf heapFormatter[T]) formatHeaps(h *reports.Heaps[T], out io.Writer, valueFormatter func(T) string, n int) {
 	banner(out, "-", "Bytes used\n")
 	hf.formatHeap(h.Bytes, out, fmtSize, valueFormatter, n)
-	if h.StorageBytes != nil {
-		banner(out, "-", "\nBytes used on underlying filesystem\n")
-		hf.formatHeap(h.StorageBytes, out, fmtSize, valueFormatter, n)
-	}
+	banner(out, "-", "\nBytes used on underlying filesystem\n")
+	hf.formatHeap(h.StorageBytes, out, fmtSize, valueFormatter, n)
 	banner(out, "-", "\nNumber of Files\n")
 	hf.formatHeap(h.Files, out, fmtCount, valueFormatter, n)
 	banner(out, "-", "\nNumber of Prefixes/Directories\n")
@@ -257,13 +253,13 @@ func (hf heapFormatter[T]) formatHeaps(h *reports.Heaps[T], out io.Writer, value
 
 func (hf heapFormatter[T]) formatTotals(h *reports.Heaps[T], out io.Writer) {
 	banner(out, "-", "Totals\n")
-	fmt.Fprintf(out, "Bytes:    %v\n", fmtSize(h.TotalBytes))
-	if h.StorageBytes != nil {
-		fmt.Fprintf(out, "Storage:  %v\n", fmtSize(h.TotalStorageBytes))
-	}
-	fmt.Fprintf(out, "Files:    %v\n", fmtCount(h.TotalFiles))
-	fmt.Fprintf(out, "Prefixes: %v\n", fmtCount(h.TotalPrefixes))
-	fmt.Fprintf(out, "Total:    %v\n\n", fmtCount(h.TotalFiles+h.TotalPrefixes))
+	fmt.Fprintf(out, "Bytes:     %v (%v)\n", fmtSize(h.TotalBytes), fmtKiBytes(h.TotalBytes))
+	fmt.Fprintf(out, "Storage:   %v (%v)\n", fmtSize(h.TotalStorageBytes), fmtKiBytes(h.TotalStorageBytes))
+	fmt.Fprintf(out, "Files:     %v\n", fmtCount(h.TotalFiles))
+	fmt.Fprintf(out, "Prefixes:  %v\n", fmtCount(h.TotalPrefixes))
+	fmt.Fprintf(out, "Total:     %v\n", fmtCount(h.TotalFiles+h.TotalPrefixes))
+	fmt.Fprintf(out, "Links:     %v\n", fmtCount(h.TotalHardlinks))
+	fmt.Fprintf(out, "Link dirs: %v\n\n", fmtCount(h.TotalHardlinkDirs))
 }
 
 func (st *statsCmds) formatPerIDStats(s reports.PerIDStats, out io.Writer, nameForID func(int64) string, ids map[int64]bool, n int) {

--- a/stats/totals_test.go
+++ b/stats/totals_test.go
@@ -5,6 +5,7 @@
 package stats_test
 
 import (
+	"context"
 	"reflect"
 	"slices"
 	"sort"
@@ -12,6 +13,7 @@ import (
 	"time"
 
 	"cloudeng.io/cmd/idu/internal/boolexpr"
+	"cloudeng.io/cmd/idu/internal/prefixinfo"
 	"cloudeng.io/cmd/idu/internal/testutil"
 	"cloudeng.io/cmd/idu/stats"
 	"cloudeng.io/file"
@@ -33,21 +35,23 @@ func TestTotals(t *testing.T) {
 	ug00d, ug10d, ug01d, ug11d, ugOtherd := testutil.TestdataIDCombinationsDirs(modTime, uid, gid, 200)
 
 	perUserStats := []stats.PerIDTotals{
-		{{uid, 2, 2, 3, 6, 3}},
-		{{uid, 1, 1, 1, 2, 1}, {uid + 1, 1, 1, 2, 4, 2}},
-		{{uid, 2, 2, 3, 6, 3}},
-		{{uid, 1, 1, 1, 2, 1}, {uid + 1, 1, 1, 2, 4, 2}},
-		{{uid + 1, 2, 2, 3, 6, 3}},
+		{{uid, 2, 1, 4, 8, 1, 0, 0}},
+		{{uid, 1, 1, 2, 4, 1, 0, 0}, {uid + 1, 1, 0, 2, 4, 0, 0, 0}},
+		{{uid, 2, 1, 4, 8, 1, 0, 0}},
+		{{uid, 1, 1, 2, 4, 1, 0, 0}, {uid + 1, 1, 0, 2, 4, 0, 0, 0}},
+		{{uid, 0, 1, 1, 2, 1, 0, 0}, {uid + 1, 2, 0, 3, 6, 0, 0, 0}},
 	}
 	perGroupStats := []stats.PerIDTotals{
-		{{gid, 2, 2, 3, 6, 3}},
-		{{gid, 2, 2, 3, 6, 3}},
-		{{gid, 1, 1, 1, 2, 1}, {gid + 1, 1, 1, 2, 4, 2}},
-		{{gid, 1, 1, 1, 2, 1}, {gid + 1, 1, 1, 2, 4, 2}},
-		{{gid + 1, 2, 2, 3, 6, 3}},
+		{{gid, 2, 1, 4, 8, 1, 0, 0}},
+		{{gid, 2, 1, 4, 8, 1, 0, 0}},
+		{{gid, 1, 1, 2, 4, 1, 0, 0}, {gid + 1, 1, 0, 2, 4, 0, 0, 0}},
+		{{gid, 1, 1, 2, 4, 1, 0, 0}, {gid + 1, 1, 0, 2, 4, 0, 0, 0}},
+		{{gid, 0, 1, 1, 2, 1, 0, 0}, {gid + 1, 2, 0, 3, 6, 0, 0, 0}},
 	}
 
-	for _, tc := range []struct {
+	parser := boolexpr.NewParserTests(context.Background(), nil)
+
+	for i, tc := range []struct {
 		fi         []file.Info
 		fd         []file.Info
 		uids, gids []int64
@@ -57,18 +61,21 @@ func TestTotals(t *testing.T) {
 		{ug10, ug10d, []int64{uid, uid + 1}, []int64{gid}, 1},
 		{ug01, ug01d, []int64{uid}, []int64{gid, gid + 1}, 2},
 		{ug11, ug11d, []int64{uid, uid + 1}, []int64{gid, gid + 1}, 3},
-		{ugOther, ugOtherd, []int64{uid + 1}, []int64{gid + 1}, 4},
+		{ugOther, ugOtherd, []int64{uid, uid + 1}, []int64{gid, gid + 1}, 4},
 	} {
+		if i != 4 {
+			continue
+		}
 		pi := testutil.TestdataNewPrefixInfo("dir", 1, 1, 0700, modTime, uid, gid, 33, 100)
 		pi.AppendInfoList(tc.fi)
 		pi.AppendInfoList(tc.fd)
 
-		totals, us, gs := stats.ComputeTotals("", &pi, sumSizeAndBlocks{}, boolexpr.AlwaysMatch{})
+		totals, us, gs := stats.ComputeTotals("", &pi, sumSizeAndBlocks{}, boolexpr.AlwaysMatch(parser))
 
 		sort.Slice(us, func(i, j int) bool { return us[i].ID < us[j].ID })
 		sort.Slice(gs, func(i, j int) bool { return gs[i].ID < gs[j].ID })
 
-		if got, want := totals, (stats.Totals{Files: 2, Prefixes: 2, Bytes: 3, StorageBytes: 3 * 2, PrefixBytes: 3}); !reflect.DeepEqual(got, want) {
+		if got, want := totals, (stats.Totals{Files: 2, Prefixes: 1, Bytes: 4, StorageBytes: 4 * 2, PrefixBytes: 1}); !reflect.DeepEqual(got, want) {
 			t.Errorf("got %#v, want %#v", got, want)
 		}
 
@@ -81,7 +88,7 @@ func TestTotals(t *testing.T) {
 			t.Fatal(err)
 		}
 		if got, want := nstats, totals; !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
+			t.Errorf("got %#v, want %#v", got, want)
 		}
 
 		for _, ugs := range []stats.PerIDTotals{us, gs} {
@@ -99,19 +106,19 @@ func TestTotals(t *testing.T) {
 		}
 
 		if got, want := us, perUserStats[tc.perIDStats]; !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
+			t.Errorf("%v: got %v, want %v", i, got, want)
 		}
 
 		if got, want := gs, perGroupStats[tc.perIDStats]; !reflect.DeepEqual(got, want) {
-			t.Errorf("got %v, want %v", got, want)
+			t.Errorf("%v: got %v, want %v", i, got, want)
 		}
 
 		if got, want := IDsFromStats(us), tc.uids; !slices.Equal(got, want) {
-			t.Errorf("got %v, want %v", got, want)
+			t.Errorf("%v: got %v, want %v", i, got, want)
 		}
 
 		if got, want := IDsFromStats(gs), tc.gids; !slices.Equal(got, want) {
-			t.Errorf("got %v, want %v", got, want)
+			t.Errorf("%v: got %v, want %v", i, got, want)
 		}
 	}
 }
@@ -122,4 +129,105 @@ func IDsFromStats(s stats.PerIDTotals) []int64 {
 		r = append(r, st.ID)
 	}
 	return r
+}
+
+func computeWithExpression(t *testing.T, pi *prefixinfo.T, expr string) (totals stats.Totals, perUser, perGroup stats.PerIDTotals) {
+	t.Helper()
+	parser := boolexpr.NewParserTests(context.Background(), nil)
+	matcher, err := boolexpr.CreateMatcher(parser,
+		boolexpr.WithEntryExpression(expr))
+	if err != nil {
+		t.Fatal(err)
+	}
+	totals, perUser, perGroup = stats.ComputeTotals("", pi, sumSizeAndBlocks{}, matcher)
+
+	sort.Slice(perUser,
+		func(i, j int) bool { return perUser[i].ID < perUser[j].ID })
+	sort.Slice(perGroup,
+		func(i, j int) bool { return perGroup[i].ID < perGroup[j].ID })
+	return totals, perUser, perGroup
+}
+
+func testLens(t *testing.T, perUser, perGroup stats.PerIDTotals, nUsers, nGroups int) {
+	t.Helper()
+	if got, want := len(perUser), nUsers; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+	if got, want := len(perGroup), nGroups; got != want {
+		t.Errorf("got %v, want %v", got, want)
+	}
+}
+
+func TestTotalsMatch(t *testing.T) {
+	modTime := time.Now().Truncate(0)
+	var uid, gid int64 = 100, 2
+
+	_, ug01, ug10, _, _ := testutil.TestdataIDCombinationsFiles(modTime, uid, gid, 100)
+	_, ug01d, ug10d, _, _ := testutil.TestdataIDCombinationsDirs(modTime, uid, gid, 200)
+
+	pi := testutil.TestdataNewPrefixInfo("my-prefix", 3, 4, 0700, modTime, uid, gid, 33, 100)
+	pi.AppendInfoList(ug01)
+	pi.AppendInfoList(ug01d)
+	pi.AppendInfoList(ug10)
+	pi.AppendInfoList(ug10d)
+
+	totals, us, gs := computeWithExpression(t, &pi, "(user=100||user=101) && (group=2||group=3)")
+
+	if got, want := totals, (stats.Totals{Files: 4, Prefixes: 1, Bytes: 3 + 6, StorageBytes: 7 + 2 + 4 + 2 + 4, PrefixBytes: 3}); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	testLens(t, us, gs, 2, 2)
+
+	totalsA := stats.Totals{Files: 3, Prefixes: 1, Bytes: 3 + 4, StorageBytes: 7 + 2 + 2 + 4, PrefixBytes: 3}
+	totalsB := stats.Totals{Files: 1, Prefixes: 0, Bytes: 2, StorageBytes: 4, PrefixBytes: 0}
+
+	uid100 := totalsA
+	uid100.ID = 100
+	uid101 := totalsB
+	uid101.ID = 101
+	gid2 := totalsA
+	gid2.ID = 2
+	gid3 := totalsB
+	gid3.ID = 3
+
+	if got, want := us[0], uid100; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	if got, want := us[1], uid101; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	if got, want := gs[0], gid2; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	if got, want := gs[1], gid3; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	totals, us, gs = computeWithExpression(t, &pi, "user=100")
+
+	testLens(t, us, gs, 1, 2)
+
+	if got, want := us[0], uid100; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	gid2User100 := stats.Totals{ID: 2, Files: 2, Prefixes: 1, Bytes: 3 + 2, StorageBytes: 7 + 2 + 2, PrefixBytes: 3}
+	if got, want := gs[0], gid2User100; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	if got, want := gs[1], gid3; !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+
+	totals, us, gs = computeWithExpression(t, &pi, "name=not-there")
+
+	if got, want := totals, (stats.Totals{}); !reflect.DeepEqual(got, want) {
+		t.Errorf("got %#v, want %#v", got, want)
+	}
+	testLens(t, us, gs, 0, 0)
 }

--- a/stats/totals_test.go
+++ b/stats/totals_test.go
@@ -207,7 +207,7 @@ func TestTotalsMatch(t *testing.T) {
 		t.Errorf("got %#v, want %#v", got, want)
 	}
 
-	totals, us, gs = computeWithExpression(t, &pi, "user=100")
+	_, us, gs = computeWithExpression(t, &pi, "user=100")
 
 	testLens(t, us, gs, 1, 2)
 


### PR DESCRIPTION
ComputeStates on a prefix now counts the directory/prefix itself and only counts files in that directory. This differs from the prior behaviour where files and directories were counted whilst iterating over the directory containing them. stats.ComputeTotals will return 1 or 0 for the number of prefixes, with 0 meaning the prefix is not matched by the match expression.  The directory sizes are now calculated correctly.

The matcher is now simplified and no longer abstract.

The groundwork is also laid for non-numeric UID/GIDs.