### PR TITLE
Add and change command line flags

### DIFF
--- a/find.go
+++ b/find.go
@@ -21,7 +21,7 @@ import (
 )
 
 type findFlags struct {
-	Long   bool            `subcmd:"long,false,'show long listing for each result'"`
+	Long   bool            `subcmd:"l,false,'show long listing for each result'"`
 	Prefix flags.Repeating `subcmd:"prefix,,'prefix match expression'"`
 }
 
@@ -35,7 +35,8 @@ func (fc *findCmds) find(ctx context.Context, values interface{}, args []string)
 
 func printPrefix(pi prefixinfo.T, long bool, k string) {
 	if long {
-		fmt.Println(fs.FormatFileInfo(internal.PrefixInfoAsFSInfo(pi, k)))
+		xattr := pi.XAttr()
+		fmt.Printf("%s uid: %v gid: %v\n", fs.FormatFileInfo(internal.PrefixInfoAsFSInfo(pi, k)), xattr.UID, xattr.GID)
 	} else {
 		fmt.Printf("%v\n", k)
 	}
@@ -43,7 +44,8 @@ func printPrefix(pi prefixinfo.T, long bool, k string) {
 
 func printEntry(pi prefixinfo.T, fi file.Info, long bool, sep, k string) {
 	if long {
-		fmt.Println("    ", fs.FormatFileInfo(fi))
+		xattr := pi.XAttrInfo(fi)
+		fmt.Printf("    %s uid: %v gid: %v\n", fs.FormatFileInfo(fi), xattr.UID, xattr.GID)
 	} else {
 		n := strings.TrimSuffix(k, sep) + sep + fi.Name()
 		fmt.Printf("%v\n", n)

--- a/main_test.go
+++ b/main_test.go
@@ -72,7 +72,7 @@ func TestHelp(t *testing.T) {
 	out, _ = runIDU("help", "analyze") // will return exit status 1 for help.
 
 	err = containsAnyOf(out, "Usage of command analyze: analyze the file system to build a database of directory and file metadata.",
-		"analyze [--progress=true --show-defaults=false --slow-scan-duration=10s] <prefix>")
+		"analyze [--force=false --progress=true --show-defaults=false --slow-scan-duration=10s] <prefix>")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
1. Add -force to analyze command to bypass the logic for 'unchanged' files, ie. to force a database update.
2. Change find --long to find --l, since that seems a more natural choice
3. Remove stats compute --stdout, and replace it with --stats-file. --stats-file=- will write to stdout, otherwise the specified file is used. Using stats-file overrides --stats-dir.